### PR TITLE
Set APRS_Random by default. Otherwise the tracker program will crash

### DIFF
--- a/boot/pisky.txt
+++ b/boot/pisky.txt
@@ -29,6 +29,7 @@ prediction_id=XX
 #APRS_Callsign=CHANGE
 APRS_ID=11
 APRS_Period=1
+APRS_Random=5
 
 #LORA_Frequency_0=434.450
 #LORA_Payload_0=CHANGEME

--- a/tracker/send_aprs
+++ b/tracker/send_aprs
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd /home/pi/pits/tracker
 echo Redirect audio to GPIO ...
-sudo ./pwm_switch
+gpio -g mode 18 pwm
 echo Set APRS volume ...
 amixer set PCM -- 400
 


### PR DESCRIPTION
The Tracker Binary fails if this value is unset. 
